### PR TITLE
fix(security): prevent Host Header Injection in email links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@ S3_UPLOAD_CONCURRENCY=8
 S3_FORCE_PATH_STYLE=true
 
 # Backward-compatible aliases also supported by script: OSS_*
+
+# Public base URL used to construct links in outgoing emails
+# (password reset, email verification).
+# REQUIRED in production. The HTTP Host header is not trusted
+# to prevent Host Header Injection attacks.
+PUBLIC_BASE_URL=http://localhost:3000

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -74,6 +74,7 @@ export default defineNuxtConfig({
         jwtSecret: process.env.JWT_SECRET || 'dev-secret-change-in-production',
         databaseUrl: process.env.DATABASE_URL || '',
         redisUrl: process.env.REDIS_URL || 'redis://localhost:6379',
+        publicBaseUrl: process.env.PUBLIC_BASE_URL || '',
         public: {
             appName: 'CP OAuth',
             i18n: {

--- a/server/api/auth/me.ts
+++ b/server/api/auth/me.ts
@@ -3,15 +3,10 @@ import { getUserIdFromEvent } from '~/server/utils/auth';
 import { sendVerificationEmail } from '~/server/utils/mailer';
 import crypto from 'crypto';
 import { USERNAME_RULE_MESSAGE, isValidUsername, normalizeUsername } from '~/utils/username';
+import { getPublicBaseUrl } from '~/server/utils/base-url';
 
 function isValidEmail(email: string): boolean {
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
-}
-
-function getBaseUrl(event: Parameters<typeof getRequestURL>[0]): string {
-    const host = getHeader(event, 'host') || 'localhost:3000';
-    const protocol = host.startsWith('localhost') ? 'http' : 'https';
-    return `${protocol}://${host}`;
 }
 
 export default defineEventHandler(async event => {
@@ -114,7 +109,7 @@ export default defineEventHandler(async event => {
                 const sent = await sendVerificationEmail(
                     email,
                     emailVerifyToken,
-                    getBaseUrl(event)
+                    getPublicBaseUrl()
                 );
                 if (!sent) {
                     throw createError({ statusCode: 503, message: 'SMTP is not configured' });

--- a/server/api/auth/password/forgot.post.ts
+++ b/server/api/auth/password/forgot.post.ts
@@ -1,12 +1,7 @@
 import crypto from 'crypto';
 import prisma from '~/server/utils/prisma';
 import { sendPasswordResetEmail } from '~/server/utils/mailer';
-
-function getBaseUrl(event: Parameters<typeof getRequestURL>[0]): string {
-    const host = getHeader(event, 'host') || 'localhost:3000';
-    const protocol = host.startsWith('localhost') ? 'http' : 'https';
-    return `${protocol}://${host}`;
-}
+import { getPublicBaseUrl } from '~/server/utils/base-url';
 
 export default defineEventHandler(async event => {
     const body = await readBody(event);
@@ -37,7 +32,7 @@ export default defineEventHandler(async event => {
         }
     });
 
-    await sendPasswordResetEmail(user.email, token, getBaseUrl(event));
+    await sendPasswordResetEmail(user.email, token, getPublicBaseUrl());
 
     return { success: true };
 });

--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -5,6 +5,7 @@ import jwt from 'jsonwebtoken';
 import prisma from '~/server/utils/prisma';
 import { getConfig } from '~/server/utils/config';
 import { sendVerificationEmail } from '~/server/utils/mailer';
+import { getPublicBaseUrl } from '~/server/utils/base-url';
 import { USERNAME_RULE_MESSAGE, isValidUsername, normalizeUsername } from '~/utils/username';
 
 const logger = consola.withTag('auth:register');
@@ -73,10 +74,7 @@ export default defineEventHandler(async event => {
     logger.success(`User registered: ${normalizedUsername} (${user.id}), role=${role}`);
 
     // Attempt to send verification email
-    const host = getHeader(event, 'host') || 'localhost:3000';
-    const protocol = host.startsWith('localhost') ? 'http' : 'https';
-    const baseUrl = `${protocol}://${host}`;
-    await sendVerificationEmail(email, emailVerifyToken, baseUrl);
+    await sendVerificationEmail(email, emailVerifyToken, getPublicBaseUrl());
 
     const config = useRuntimeConfig();
     const token = jwt.sign({ userId: user.id }, config.jwtSecret, { expiresIn: '7d' });

--- a/server/api/auth/verify.post.ts
+++ b/server/api/auth/verify.post.ts
@@ -3,12 +3,7 @@ import { getUserIdFromEvent } from '~/server/utils/auth';
 import prisma from '~/server/utils/prisma';
 import { sendVerificationEmail } from '~/server/utils/mailer';
 import { isOAuthGeneratedLocalEmail } from '~/server/utils/email';
-
-function getBaseUrl(event: Parameters<typeof getRequestURL>[0]): string {
-    const host = getHeader(event, 'host') || 'localhost:3000';
-    const protocol = host.startsWith('localhost') ? 'http' : 'https';
-    return `${protocol}://${host}`;
-}
+import { getPublicBaseUrl } from '~/server/utils/base-url';
 
 export default defineEventHandler(async event => {
     const userId = getUserIdFromEvent(event);
@@ -43,7 +38,7 @@ export default defineEventHandler(async event => {
         data: { emailVerifyToken }
     });
 
-    const sent = await sendVerificationEmail(user.email, emailVerifyToken, getBaseUrl(event));
+    const sent = await sendVerificationEmail(user.email, emailVerifyToken, getPublicBaseUrl());
     if (!sent) {
         throw createError({ statusCode: 503, message: 'SMTP is not configured' });
     }

--- a/server/utils/base-url.ts
+++ b/server/utils/base-url.ts
@@ -1,0 +1,24 @@
+import type { H3Event } from 'h3';
+
+/**
+ * Returns the base URL for generating links in outgoing emails
+ * (password reset, email verification, etc.).
+ *
+ * Always reads from the PUBLIC_BASE_URL runtime config.
+ * The HTTP Host header is NOT trusted, to prevent Host Header Injection
+ * attacks where a forged Host header would cause sensitive tokens
+ * (e.g. password reset tokens) to be sent to attacker-controlled domains.
+ *
+ * @see https://owasp.org/www-community/attacks/Host_Header_Injection
+ */
+export function getPublicBaseUrl(_event?: H3Event): string {
+    const config = useRuntimeConfig();
+    const baseUrl = config.publicBaseUrl;
+    if (!baseUrl) {
+        throw createError({
+            statusCode: 500,
+            message: 'PUBLIC_BASE_URL is not configured'
+        });
+    }
+    return baseUrl.replace(/\/+$/, '');
+}


### PR DESCRIPTION
The getBaseUrl() helper (duplicated across 3 files plus 1 inline copy) trusted the HTTP Host header when building base URLs for password reset and email verification links. An attacker could send a request with a forged Host header (e.g. "Host: evil.com") to make the server send emails containing links pointing to attacker-controlled domains, leaking sensitive tokens.

Replace all four call sites with a new getPublicBaseUrl() helper in server/utils/base-url.ts that reads from the PUBLIC_BASE_URL runtime config and never trusts the Host header. The new helper throws 500 if PUBLIC_BASE_URL is not configured (fail-loud), which is appropriate for a production security control.

Affected files: server/api/auth/me.ts, server/api/auth/password/forgot.post.ts, server/api/auth/register.post.ts, server/api/auth/verify.post.ts.

Closes #11