### PR TITLE
fix(security): hash password reset and email verify tokens at rest

### DIFF
--- a/server/api/auth/me.ts
+++ b/server/api/auth/me.ts
@@ -2,6 +2,7 @@ import prisma from '~/server/utils/prisma';
 import { getUserIdFromEvent } from '~/server/utils/auth';
 import { sendVerificationEmail } from '~/server/utils/mailer';
 import crypto from 'crypto';
+import { hashToken } from '~/server/utils/token-hash';
 import { USERNAME_RULE_MESSAGE, isValidUsername, normalizeUsername } from '~/utils/username';
 
 function isValidEmail(email: string): boolean {
@@ -110,7 +111,7 @@ export default defineEventHandler(async event => {
                 const emailVerifyToken = crypto.randomBytes(32).toString('hex');
                 data.email = email;
                 data.emailVerified = false;
-                data.emailVerifyToken = emailVerifyToken;
+                data.emailVerifyToken = hashToken(emailVerifyToken);
                 const sent = await sendVerificationEmail(
                     email,
                     emailVerifyToken,

--- a/server/api/auth/password/forgot.post.ts
+++ b/server/api/auth/password/forgot.post.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import prisma from '~/server/utils/prisma';
 import { sendPasswordResetEmail } from '~/server/utils/mailer';
+import { hashToken } from '~/server/utils/token-hash';
 
 function getBaseUrl(event: Parameters<typeof getRequestURL>[0]): string {
     const host = getHeader(event, 'host') || 'localhost:3000';
@@ -32,7 +33,7 @@ export default defineEventHandler(async event => {
     await prisma.user.update({
         where: { id: user.id },
         data: {
-            passwordResetToken: token,
+            passwordResetToken: hashToken(token),
             passwordResetExpiresAt: expiresAt
         }
     });

--- a/server/api/auth/password/reset.post.ts
+++ b/server/api/auth/password/reset.post.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcryptjs';
 import prisma from '~/server/utils/prisma';
+import { hashToken } from '~/server/utils/token-hash';
 
 export default defineEventHandler(async event => {
     const body = await readBody(event);
@@ -15,7 +16,7 @@ export default defineEventHandler(async event => {
     }
 
     const user = await prisma.user.findUnique({
-        where: { passwordResetToken: token },
+        where: { passwordResetToken: hashToken(token) },
         select: { id: true, passwordResetExpiresAt: true }
     });
 

--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -5,6 +5,7 @@ import jwt from 'jsonwebtoken';
 import prisma from '~/server/utils/prisma';
 import { getConfig } from '~/server/utils/config';
 import { sendVerificationEmail } from '~/server/utils/mailer';
+import { hashToken } from '~/server/utils/token-hash';
 import { USERNAME_RULE_MESSAGE, isValidUsername, normalizeUsername } from '~/utils/username';
 
 const logger = consola.withTag('auth:register');
@@ -67,7 +68,13 @@ export default defineEventHandler(async event => {
     const role = userCount === 0 ? 'admin' : 'user';
 
     const user = await prisma.user.create({
-        data: { username: normalizedUsername, email, passwordHash, emailVerifyToken, role }
+        data: {
+            username: normalizedUsername,
+            email,
+            passwordHash,
+            emailVerifyToken: hashToken(emailVerifyToken),
+            role
+        }
     });
 
     logger.success(`User registered: ${normalizedUsername} (${user.id}), role=${role}`);

--- a/server/api/auth/verify.get.ts
+++ b/server/api/auth/verify.get.ts
@@ -1,6 +1,7 @@
 import { consola } from 'consola';
 import prisma from '~/server/utils/prisma';
 import { isOAuthGeneratedLocalEmail } from '~/server/utils/email';
+import { hashToken } from '~/server/utils/token-hash';
 
 const logger = consola.withTag('auth:verify');
 
@@ -12,7 +13,7 @@ export default defineEventHandler(async event => {
         return sendRedirect(event, '/email-verified?status=error');
     }
 
-    const user = await prisma.user.findUnique({ where: { emailVerifyToken: token } });
+    const user = await prisma.user.findUnique({ where: { emailVerifyToken: hashToken(token) } });
     if (!user) {
         logger.warn('Email verification failed: invalid or expired token');
         return sendRedirect(event, '/email-verified?status=error');

--- a/server/api/auth/verify.post.ts
+++ b/server/api/auth/verify.post.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { getUserIdFromEvent } from '~/server/utils/auth';
 import prisma from '~/server/utils/prisma';
 import { sendVerificationEmail } from '~/server/utils/mailer';
+import { hashToken } from '~/server/utils/token-hash';
 import { isOAuthGeneratedLocalEmail } from '~/server/utils/email';
 
 function getBaseUrl(event: Parameters<typeof getRequestURL>[0]): string {
@@ -40,7 +41,7 @@ export default defineEventHandler(async event => {
     const emailVerifyToken = crypto.randomBytes(32).toString('hex');
     await prisma.user.update({
         where: { id: userId },
-        data: { emailVerifyToken }
+        data: { emailVerifyToken: hashToken(emailVerifyToken) }
     });
 
     const sent = await sendVerificationEmail(user.email, emailVerifyToken, getBaseUrl(event));

--- a/server/utils/token-hash.ts
+++ b/server/utils/token-hash.ts
@@ -1,0 +1,12 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Hashes a high-entropy token (e.g. crypto.randomBytes output) for
+ * at-rest storage. Uses SHA-256 to keep findUnique lookups O(1).
+ *
+ * WARNING: Do NOT use for user passwords — low-entropy inputs require
+ * a slow KDF (bcrypt or Argon2id).
+ */
+export function hashToken(rawToken: string): string {
+    return createHash('sha256').update(rawToken).digest('hex');
+}


### PR DESCRIPTION
Previously, passwordResetToken and emailVerifyToken were stored as plaintext in the users table. If the database were ever compromised (SQL injection, backup leak, insider access), an attacker could directly use any unexpired token to reset passwords or verify emails of arbitrary accounts.

Hash these tokens with SHA-256 before storing them. The unhashed token is still what's sent in the verification email link — when the user clicks it, the server hashes the incoming token and looks it up by the hashed value.

A new helper hashToken() is added in server/utils/token-hash.ts with a WARNING comment to prevent future misuse on low-entropy inputs.

Existing in-flight tokens will become unusable after deployment, but reset tokens expire in 30 minutes anyway so the impact window is minimal.

Closes #12