### PR TITLE
fix(oauth): require client authentication on refresh and revoke endpo…

### DIFF
--- a/server/api/oauth/revoke.post.ts
+++ b/server/api/oauth/revoke.post.ts
@@ -1,15 +1,23 @@
 import { consola } from 'consola';
+import { authenticateOAuthClient } from '~/server/utils/oauth';
 import prisma from '~/server/utils/prisma';
 
 const logger = consola.withTag('oauth:revoke');
 
 export default defineEventHandler(async event => {
     const body = await readBody(event);
-    const { token, token_type_hint: tokenTypeHint } = body;
+    const {
+        token,
+        token_type_hint: tokenTypeHint,
+        client_id: clientId,
+        client_secret: clientSecret
+    } = body;
 
     if (!token) {
         throw createError({ statusCode: 400, message: 'Missing required parameter: token' });
     }
+    // Authenticate the client (RFC 7009 §2.1)
+    await authenticateOAuthClient(clientId, clientSecret);
 
     // Try to find and revoke the token
     // Per RFC 7009, always return 200 regardless of whether the token was found

--- a/server/api/oauth/token.post.ts
+++ b/server/api/oauth/token.post.ts
@@ -2,7 +2,7 @@ import { consola } from 'consola';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import prisma from '~/server/utils/prisma';
-import { verifyPKCE, generateRefreshToken } from '~/server/utils/oauth';
+import { verifyPKCE, generateRefreshToken, authenticateOAuthClient } from '~/server/utils/oauth';
 
 const logger = consola.withTag('oauth:token');
 
@@ -190,23 +190,8 @@ async function handleRefreshToken(body: Record<string, string>) {
         throw createError({ statusCode: 400, message: 'client_id mismatch' });
     }
 
-    // Verify client_secret for confidential clients
-    // Check if the original authorization used PKCE (no secret needed)
-    const client = await prisma.oAuthClient.findUnique({ where: { clientId } });
-    if (!client) {
-        throw createError({ statusCode: 400, message: 'Unknown client' });
-    }
-
-    // If client_secret is provided, verify it; otherwise we allow PKCE public clients through
-    if (clientSecret) {
-        const valid = await bcrypt.compare(clientSecret, client.clientSecretHash);
-        if (!valid) {
-            logger.warn(
-                `Rejected: invalid client_secret for "${client.name}" (${clientId}) during refresh`
-            );
-            throw createError({ statusCode: 401, message: 'Invalid client_secret' });
-        }
-    }
+    // Authenticate the client (RFC 6749 §2.3.1)
+    await authenticateOAuthClient(clientId, clientSecret);
 
     // Rotation: revoke old refresh token and issue new ones
     const newAccessToken = issueAccessToken(

--- a/server/utils/oauth.ts
+++ b/server/utils/oauth.ts
@@ -1,4 +1,6 @@
 import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
+import prisma from '~/server/utils/prisma';
 
 export const SCOPES = {
     openid: 'Base identity (user ID)',
@@ -50,4 +52,37 @@ export function verifyPKCE(
         return hash === codeChallenge;
     }
     return false;
+}
+/**
+ * Authenticates an OAuth client by verifying client_id and client_secret.
+ *
+ * Per OAuth 2.0 (RFC 6749 §2.3.1) and RFC 7009 §2.1, confidential clients
+ * MUST be authenticated when calling token / revoke endpoints. cp-oauth's
+ * data model requires every client to have a secret (clientSecretHash is
+ * non-nullable), so all clients are treated as confidential.
+ *
+ * Returns the client record on success; throws on any failure.
+ *
+ * Error responses intentionally don't distinguish "unknown client" from
+ * "wrong secret" to prevent client_id enumeration.
+ */
+export async function authenticateOAuthClient(
+    clientId: string | undefined,
+    clientSecret: string | undefined
+) {
+    if (!clientId) {
+        throw createError({ statusCode: 400, message: 'client_id required' });
+    }
+    if (!clientSecret) {
+        throw createError({ statusCode: 400, message: 'client_secret required' });
+    }
+    const client = await prisma.oAuthClient.findUnique({ where: { clientId } });
+    if (!client) {
+        throw createError({ statusCode: 401, message: 'Invalid client credentials' });
+    }
+    const valid = await bcrypt.compare(clientSecret, client.clientSecretHash);
+    if (!valid) {
+        throw createError({ statusCode: 401, message: 'Invalid client credentials' });
+    }
+    return client;
 }


### PR DESCRIPTION
Per RFC 6749 §2.3.1 (token endpoint) and RFC 7009 §2.1 (revoke endpoint), confidential OAuth clients MUST authenticate when calling these endpoints. cp-oauth's data model requires every client to have a non-nullable clientSecretHash, so all clients are confidential.

Two issues fixed:

- #14: handleRefreshToken accepted refresh requests without client_secret. A leaked refresh token (XSS, log exposure, etc.) could be used by anyone to obtain new access/refresh tokens with no further authentication.

- #15: revoke.post.ts performed no client authentication at all. Anyone who learned a token value (e.g. from a URL log) could revoke it, disrupting legitimate users.

Both endpoints now call a new authenticateOAuthClient() helper in server/utils/oauth.ts that requires client_id + client_secret and verifies the secret via bcrypt against the stored hash. Error responses use a uniform "Invalid client credentials" message to prevent client_id enumeration.

Closes #14

Closes #15