### PR TITLE
refactor: extract findOrCreateLocalUser into shared utility

### DIFF
--- a/server/api/auth/thirdparty/clist/callback.post.ts
+++ b/server/api/auth/thirdparty/clist/callback.post.ts
@@ -327,7 +327,7 @@ export default defineEventHandler(async event => {
         displayName: identity.displayName,
         avatarUrl: identity.avatarUrl,
         usernamePrefix: 'clist_',
-        getUniqueUsername: async (base) => getClistUniqueUsername(base),
+        getUniqueUsername: getClistUniqueUsername,
         allocateSyntheticEmail,
         logger,
         refreshOnFound: true,

--- a/server/api/auth/thirdparty/clist/callback.post.ts
+++ b/server/api/auth/thirdparty/clist/callback.post.ts
@@ -10,6 +10,7 @@ import {
     resolveClistIdentity
 } from '~/server/utils/clist-oauth';
 import { createAuthUserResponse } from '~/server/utils/user-response';
+import { findOrCreateLocalUser as findOrCreateLocalUserBase } from '~/server/utils/thirdparty';
 
 const logger = consola.withTag('auth:clist:callback');
 
@@ -64,102 +65,6 @@ async function allocateSyntheticEmail(platformUid: string): Promise<string> {
     }
 
     throw createError({ statusCode: 500, message: 'Unable to allocate email for Clist user' });
-}
-
-async function findOrCreateLocalUser(identity: {
-    platformUid: string;
-    platformUsername: string;
-    email: string | null;
-    emailVerified: boolean;
-    displayName: string | null;
-    avatarUrl: string | null;
-    oauthCredentials: ClistOAuthCredentialSnapshot;
-}) {
-    const linked = await prisma.linkedAccount.findUnique({
-        where: {
-            platform_platformUid: {
-                platform: 'clist',
-                platformUid: identity.platformUid
-            }
-        },
-        include: { user: true }
-    });
-
-    if (linked) {
-        await prisma.linkedAccount.update({
-            where: { id: linked.id },
-            data: {
-                platformUsername: identity.platformUsername,
-                oauthAccessToken: identity.oauthCredentials.oauthAccessToken,
-                oauthRefreshToken: identity.oauthCredentials.oauthRefreshToken,
-                oauthTokenType: identity.oauthCredentials.oauthTokenType,
-                oauthExpiresAt: identity.oauthCredentials.oauthExpiresAt,
-                oauthScope: identity.oauthCredentials.oauthScope
-            }
-        });
-
-        return linked.user;
-    }
-
-    let user = null;
-    const normalizedEmail = normalizeUsername(identity.email);
-    if (normalizedEmail) {
-        user = await prisma.user.findUnique({ where: { email: normalizedEmail } });
-    }
-
-    if (!user) {
-        const username = await getClistUniqueUsername(
-            identity.platformUsername || `clist_${identity.platformUid}`
-        );
-        const userCount = await prisma.user.count();
-        const role = userCount === 0 ? 'admin' : 'user';
-        const email = normalizedEmail || (await allocateSyntheticEmail(identity.platformUid));
-
-        user = await prisma.user.create({
-            data: {
-                email,
-                username,
-                passwordHash: await bcrypt.hash(crypto.randomUUID(), 10),
-                displayName: identity.displayName,
-                avatarUrl: identity.avatarUrl,
-                emailVerified: normalizedEmail ? identity.emailVerified : false,
-                role
-            }
-        });
-
-        logger.info(`Created local user from Clist: user=${user.id}, username=${user.username}`);
-    }
-
-    await prisma.linkedAccount.upsert({
-        where: {
-            userId_platform: {
-                userId: user.id,
-                platform: 'clist'
-            }
-        },
-        update: {
-            platformUid: identity.platformUid,
-            platformUsername: identity.platformUsername,
-            oauthAccessToken: identity.oauthCredentials.oauthAccessToken,
-            oauthRefreshToken: identity.oauthCredentials.oauthRefreshToken,
-            oauthTokenType: identity.oauthCredentials.oauthTokenType,
-            oauthExpiresAt: identity.oauthCredentials.oauthExpiresAt,
-            oauthScope: identity.oauthCredentials.oauthScope
-        },
-        create: {
-            userId: user.id,
-            platform: 'clist',
-            platformUid: identity.platformUid,
-            platformUsername: identity.platformUsername,
-            oauthAccessToken: identity.oauthCredentials.oauthAccessToken,
-            oauthRefreshToken: identity.oauthCredentials.oauthRefreshToken,
-            oauthTokenType: identity.oauthCredentials.oauthTokenType,
-            oauthExpiresAt: identity.oauthCredentials.oauthExpiresAt,
-            oauthScope: identity.oauthCredentials.oauthScope
-        }
-    });
-
-    return user;
 }
 
 async function registerLocalUserFromClist(identity: {
@@ -413,7 +318,27 @@ export default defineEventHandler(async event => {
         };
     }
 
-    const user = await findOrCreateLocalUser({ ...identity, oauthCredentials });
+    const user = await findOrCreateLocalUserBase({
+        platform: 'clist',
+        platformUid: identity.platformUid,
+        platformUsername: identity.platformUsername,
+        email: identity.email,
+        emailVerified: identity.emailVerified,
+        displayName: identity.displayName,
+        avatarUrl: identity.avatarUrl,
+        usernamePrefix: 'clist_',
+        getUniqueUsername: async (base) => getClistUniqueUsername(base),
+        allocateSyntheticEmail,
+        logger,
+        refreshOnFound: true,
+        oauthFields: {
+            oauthAccessToken: oauthCredentials.oauthAccessToken,
+            oauthRefreshToken: oauthCredentials.oauthRefreshToken,
+            oauthTokenType: oauthCredentials.oauthTokenType,
+            oauthExpiresAt: oauthCredentials.oauthExpiresAt,
+            oauthScope: oauthCredentials.oauthScope
+        }
+    });
 
     const authToken = await signAuthToken(user.id);
 

--- a/server/api/auth/thirdparty/codeforces/callback.post.ts
+++ b/server/api/auth/thirdparty/codeforces/callback.post.ts
@@ -327,7 +327,7 @@ export default defineEventHandler(async event => {
         displayName: identity.displayName,
         avatarUrl: identity.avatarUrl,
         usernamePrefix: 'cf_',
-        getUniqueUsername: async (base) => getUniqueUsername(base),
+        getUniqueUsername,
         allocateSyntheticEmail,
         logger,
         refreshOnFound: true,

--- a/server/api/auth/thirdparty/codeforces/callback.post.ts
+++ b/server/api/auth/thirdparty/codeforces/callback.post.ts
@@ -10,6 +10,7 @@ import {
     resolveCodeforcesIdentity
 } from '~/server/utils/codeforces-oauth';
 import { createAuthUserResponse } from '~/server/utils/user-response';
+import { findOrCreateLocalUser as findOrCreateLocalUserBase } from '~/server/utils/thirdparty';
 
 const logger = consola.withTag('auth:codeforces:callback');
 
@@ -67,107 +68,6 @@ async function allocateSyntheticEmail(platformUid: string): Promise<string> {
     }
 
     throw createError({ statusCode: 500, message: 'Unable to allocate email for Codeforces user' });
-}
-
-async function findOrCreateLocalUser(identity: {
-    platformUid: string;
-    platformUsername: string;
-    email: string | null;
-    emailVerified: boolean;
-    displayName: string | null;
-    avatarUrl: string | null;
-    oauthCredentials: CodeforcesOAuthCredentialSnapshot;
-}) {
-    const linked = await prisma.linkedAccount.findUnique({
-        where: {
-            platform_platformUid: {
-                platform: 'codeforces',
-                platformUid: identity.platformUid
-            }
-        },
-        include: { user: true }
-    });
-
-    if (linked) {
-        await prisma.linkedAccount.update({
-            where: { id: linked.id },
-            data: {
-                platformUsername: identity.platformUsername,
-                oauthAccessToken: identity.oauthCredentials.oauthAccessToken,
-                oauthRefreshToken: identity.oauthCredentials.oauthRefreshToken,
-                oauthIdToken: identity.oauthCredentials.oauthIdToken,
-                oauthTokenType: identity.oauthCredentials.oauthTokenType,
-                oauthExpiresAt: identity.oauthCredentials.oauthExpiresAt,
-                oauthScope: identity.oauthCredentials.oauthScope
-            }
-        });
-
-        return linked.user;
-    }
-
-    let user = null;
-    const normalizedEmail = normalizeUsername(identity.email);
-    if (normalizedEmail) {
-        user = await prisma.user.findUnique({ where: { email: normalizedEmail } });
-    }
-
-    if (!user) {
-        const username = await getUniqueUsername(
-            identity.platformUsername || `cf_${identity.platformUid}`
-        );
-        const userCount = await prisma.user.count();
-        const role = userCount === 0 ? 'admin' : 'user';
-        const email = normalizedEmail || (await allocateSyntheticEmail(identity.platformUid));
-
-        user = await prisma.user.create({
-            data: {
-                email,
-                username,
-                passwordHash: await bcrypt.hash(crypto.randomUUID(), 10),
-                displayName: identity.displayName,
-                avatarUrl: identity.avatarUrl,
-                emailVerified: normalizedEmail ? identity.emailVerified : false,
-                role
-            }
-        });
-
-        logger.info(
-            `Created local user from Codeforces: user=${user.id}, username=${user.username}`
-        );
-    }
-
-    await prisma.linkedAccount.upsert({
-        where: {
-            userId_platform: {
-                userId: user.id,
-                platform: 'codeforces'
-            }
-        },
-        update: {
-            platformUid: identity.platformUid,
-            platformUsername: identity.platformUsername,
-            oauthAccessToken: identity.oauthCredentials.oauthAccessToken,
-            oauthRefreshToken: identity.oauthCredentials.oauthRefreshToken,
-            oauthIdToken: identity.oauthCredentials.oauthIdToken,
-            oauthTokenType: identity.oauthCredentials.oauthTokenType,
-            oauthExpiresAt: identity.oauthCredentials.oauthExpiresAt,
-            oauthScope: identity.oauthCredentials.oauthScope
-        },
-        create: {
-            userId: user.id,
-            platform: 'codeforces',
-            platformUid: identity.platformUid,
-            platformUsername: identity.platformUsername,
-            oauthAccessToken: identity.oauthCredentials.oauthAccessToken,
-            oauthRefreshToken: identity.oauthCredentials.oauthRefreshToken,
-            oauthIdToken: identity.oauthCredentials.oauthIdToken,
-            oauthTokenType: identity.oauthCredentials.oauthTokenType,
-            oauthExpiresAt: identity.oauthCredentials.oauthExpiresAt,
-            oauthScope: identity.oauthCredentials.oauthScope
-        }
-    });
-
-    return user;
 }
 
 async function registerLocalUserFromCodeforces(identity: {
@@ -418,7 +318,28 @@ export default defineEventHandler(async event => {
         };
     }
 
-    const user = await findOrCreateLocalUser({ ...identity, oauthCredentials });
+    const user = await findOrCreateLocalUserBase({
+        platform: 'codeforces',
+        platformUid: identity.platformUid,
+        platformUsername: identity.platformUsername,
+        email: identity.email,
+        emailVerified: identity.emailVerified,
+        displayName: identity.displayName,
+        avatarUrl: identity.avatarUrl,
+        usernamePrefix: 'cf_',
+        getUniqueUsername: async (base) => getUniqueUsername(base),
+        allocateSyntheticEmail,
+        logger,
+        refreshOnFound: true,
+        oauthFields: {
+            oauthAccessToken: oauthCredentials.oauthAccessToken,
+            oauthRefreshToken: oauthCredentials.oauthRefreshToken,
+            oauthIdToken: oauthCredentials.oauthIdToken,
+            oauthTokenType: oauthCredentials.oauthTokenType,
+            oauthExpiresAt: oauthCredentials.oauthExpiresAt,
+            oauthScope: oauthCredentials.oauthScope
+        }
+    });
 
     const authToken = await signAuthToken(user.id);
 

--- a/server/api/auth/thirdparty/github/callback.post.ts
+++ b/server/api/auth/thirdparty/github/callback.post.ts
@@ -309,7 +309,7 @@ export default defineEventHandler(async event => {
         displayName: identity.displayName,
         avatarUrl: identity.avatarUrl,
         usernamePrefix: 'gh_',
-        getUniqueUsername: async (base) => getUniqueUsername(base),
+        getUniqueUsername,
         allocateSyntheticEmail,
         oauthFields: {
             oauthAccessToken: githubToken.accessToken,

--- a/server/api/auth/thirdparty/github/callback.post.ts
+++ b/server/api/auth/thirdparty/github/callback.post.ts
@@ -10,6 +10,7 @@ import {
 import { getUniqueUsername } from '~/server/utils/codeforces-oauth';
 import { fetchPlatformUsername } from '~/server/utils/platform-username';
 import { createAuthUserResponse } from '~/server/utils/user-response';
+import { findOrCreateLocalUser as findOrCreateLocalUserBase } from '~/server/utils/thirdparty';
 
 interface GitHubTokenPayload {
     accessToken: string;
@@ -36,84 +37,6 @@ async function allocateSyntheticEmail(platformUid: string): Promise<string> {
         if (!existing) return candidate;
     }
     throw createError({ statusCode: 500, message: 'Unable to allocate email for GitHub user' });
-}
-
-async function findOrCreateLocalUser(
-    identity: {
-        platformUid: string;
-        platformUsername: string;
-        email: string | null;
-        emailVerified: boolean;
-        displayName: string | null;
-        avatarUrl: string | null;
-    },
-    token: GitHubTokenPayload
-) {
-    const linked = await prisma.linkedAccount.findUnique({
-        where: {
-            platform_platformUid: {
-                platform: 'github',
-                platformUid: identity.platformUid
-            }
-        },
-        include: { user: true }
-    });
-
-    if (linked) return linked.user;
-
-    let user = null;
-    const normalizedEmail = normalizeUsername(identity.email);
-    if (normalizedEmail) {
-        user = await prisma.user.findUnique({ where: { email: normalizedEmail } });
-    }
-
-    if (!user) {
-        const username = await getUniqueUsername(
-            identity.platformUsername || `gh_${identity.platformUid}`
-        );
-        const userCount = await prisma.user.count();
-        const role = userCount === 0 ? 'admin' : 'user';
-        const email = normalizedEmail || (await allocateSyntheticEmail(identity.platformUid));
-
-        user = await prisma.user.create({
-            data: {
-                email,
-                username,
-                passwordHash: await bcrypt.hash(crypto.randomUUID(), 10),
-                displayName: identity.displayName,
-                avatarUrl: identity.avatarUrl,
-                emailVerified: normalizedEmail ? identity.emailVerified : false,
-                role
-            }
-        });
-    }
-
-    await prisma.linkedAccount.upsert({
-        where: {
-            userId_platform: {
-                userId: user.id,
-                platform: 'github'
-            }
-        },
-        update: {
-            platformUid: identity.platformUid,
-            platformUsername: identity.platformUsername,
-            oauthAccessToken: token.accessToken,
-            oauthTokenType: token.tokenType || 'bearer',
-            oauthScope: token.scope || null
-        },
-        create: {
-            userId: user.id,
-            platform: 'github',
-            platformUid: identity.platformUid,
-            platformUsername: identity.platformUsername,
-            oauthAccessToken: token.accessToken,
-            oauthTokenType: token.tokenType || 'bearer',
-            oauthScope: token.scope || null
-        }
-    });
-
-    return user;
 }
 
 async function registerLocalUserFromGitHub(
@@ -377,7 +300,23 @@ export default defineEventHandler(async event => {
         };
     }
 
-    const user = await findOrCreateLocalUser(identity, githubToken);
+    const user = await findOrCreateLocalUserBase({
+        platform: 'github',
+        platformUid: identity.platformUid,
+        platformUsername: identity.platformUsername,
+        email: identity.email,
+        emailVerified: identity.emailVerified,
+        displayName: identity.displayName,
+        avatarUrl: identity.avatarUrl,
+        usernamePrefix: 'gh_',
+        getUniqueUsername: async (base) => getUniqueUsername(base),
+        allocateSyntheticEmail,
+        oauthFields: {
+            oauthAccessToken: githubToken.accessToken,
+            oauthTokenType: githubToken.tokenType || 'bearer',
+            oauthScope: githubToken.scope || null
+        }
+    });
     const refreshedUsername = await fetchPlatformUsername('github', {
         platformUid: identity.platformUid,
         oauthAccessToken: githubToken.accessToken,

--- a/server/api/auth/thirdparty/google/callback.post.ts
+++ b/server/api/auth/thirdparty/google/callback.post.ts
@@ -245,7 +245,7 @@ export default defineEventHandler(async event => {
         displayName: identity.displayName,
         avatarUrl: identity.avatarUrl,
         usernamePrefix: 'go_',
-        getUniqueUsername: async (base) => getUniqueUsername(base),
+        getUniqueUsername,
         allocateSyntheticEmail
     });
     const authToken = await signAuthToken(user.id);

--- a/server/api/auth/thirdparty/google/callback.post.ts
+++ b/server/api/auth/thirdparty/google/callback.post.ts
@@ -9,6 +9,7 @@ import {
 } from '~/server/utils/google-oauth';
 import { getUniqueUsername } from '~/server/utils/codeforces-oauth';
 import { createAuthUserResponse } from '~/server/utils/user-response';
+import { findOrCreateLocalUser as findOrCreateLocalUserBase } from '~/server/utils/thirdparty';
 
 interface CallbackBody {
     code?: string;
@@ -29,75 +30,6 @@ async function allocateSyntheticEmail(platformUid: string): Promise<string> {
         if (!existing) return candidate;
     }
     throw createError({ statusCode: 500, message: 'Unable to allocate email for Google user' });
-}
-
-async function findOrCreateLocalUser(identity: {
-    platformUid: string;
-    platformUsername: string;
-    email: string | null;
-    emailVerified: boolean;
-    displayName: string | null;
-    avatarUrl: string | null;
-}) {
-    const linked = await prisma.linkedAccount.findUnique({
-        where: {
-            platform_platformUid: {
-                platform: 'google',
-                platformUid: identity.platformUid
-            }
-        },
-        include: { user: true }
-    });
-
-    if (linked) return linked.user;
-
-    let user = null;
-    const normalizedEmail = normalizeUsername(identity.email);
-    if (normalizedEmail) {
-        user = await prisma.user.findUnique({ where: { email: normalizedEmail } });
-    }
-
-    if (!user) {
-        const username = await getUniqueUsername(
-            identity.platformUsername || `go_${identity.platformUid}`
-        );
-        const userCount = await prisma.user.count();
-        const role = userCount === 0 ? 'admin' : 'user';
-        const email = normalizedEmail || (await allocateSyntheticEmail(identity.platformUid));
-
-        user = await prisma.user.create({
-            data: {
-                email,
-                username,
-                passwordHash: await bcrypt.hash(crypto.randomUUID(), 10),
-                displayName: identity.displayName,
-                avatarUrl: identity.avatarUrl,
-                emailVerified: normalizedEmail ? identity.emailVerified : false,
-                role
-            }
-        });
-    }
-
-    await prisma.linkedAccount.upsert({
-        where: {
-            userId_platform: {
-                userId: user.id,
-                platform: 'google'
-            }
-        },
-        update: {
-            platformUid: identity.platformUid,
-            platformUsername: identity.platformUsername
-        },
-        create: {
-            userId: user.id,
-            platform: 'google',
-            platformUid: identity.platformUid,
-            platformUsername: identity.platformUsername
-        }
-    });
-
-    return user;
 }
 
 async function registerLocalUserFromGoogle(identity: {
@@ -304,7 +236,18 @@ export default defineEventHandler(async event => {
         };
     }
 
-    const user = await findOrCreateLocalUser(identity);
+    const user = await findOrCreateLocalUserBase({
+        platform: 'google',
+        platformUid: identity.platformUid,
+        platformUsername: identity.platformUsername,
+        email: identity.email,
+        emailVerified: identity.emailVerified,
+        displayName: identity.displayName,
+        avatarUrl: identity.avatarUrl,
+        usernamePrefix: 'go_',
+        getUniqueUsername: async (base) => getUniqueUsername(base),
+        allocateSyntheticEmail
+    });
     const authToken = await signAuthToken(user.id);
 
     return {

--- a/server/utils/thirdparty.ts
+++ b/server/utils/thirdparty.ts
@@ -1,0 +1,144 @@
+import bcrypt from 'bcryptjs';
+import prisma from '~/server/utils/prisma';
+import { normalizeUsername } from '~/utils/username';
+
+export interface LinkedAccountOAuthFields {
+    oauthAccessToken?: string | null;
+    oauthRefreshToken?: string | null;
+    oauthIdToken?: string | null;
+    oauthTokenType?: string | null;
+    oauthExpiresAt?: Date | null;
+    oauthScope?: string | null;
+}
+
+export interface FindOrCreateLocalUserOptions {
+    platform: string;
+    platformUid: string;
+    platformUsername: string;
+    email: string | null;
+    emailVerified: boolean;
+    displayName: string | null;
+    avatarUrl: string | null;
+    usernamePrefix: string;
+    oauthFields?: LinkedAccountOAuthFields;
+    /** If true, update OAuth fields on linkedAccount even when user already linked */
+    refreshOnFound?: boolean;
+    /** Custom username generator (overrides default getUniqueUsername with prefix) */
+    getUniqueUsername?: (base: string) => Promise<string>;
+    /** Synthetic email allocator for users without email */
+    allocateSyntheticEmail?: (platformUid: string) => Promise<string>;
+    /** Logger for created user event */
+    logger?: { info: (msg: string) => void };
+}
+
+export async function findOrCreateLocalUser(opts: FindOrCreateLocalUserOptions) {
+    const {
+        platform,
+        platformUid,
+        platformUsername,
+        email: rawEmail,
+        emailVerified,
+        displayName,
+        avatarUrl,
+        usernamePrefix,
+        oauthFields,
+        refreshOnFound = false,
+        getUniqueUsername: customGetUsername,
+        allocateSyntheticEmail: customAllocEmail,
+        logger
+    } = opts;
+
+    const linked = await prisma.linkedAccount.findUnique({
+        where: {
+            platform_platformUid: {
+                platform,
+                platformUid
+            }
+        },
+        include: { user: true }
+    });
+
+    if (linked) {
+        if (refreshOnFound && oauthFields) {
+            const updateData: Record<string, unknown> = {
+                platformUsername
+            };
+            if (oauthFields.oauthAccessToken !== undefined) updateData.oauthAccessToken = oauthFields.oauthAccessToken;
+            if (oauthFields.oauthRefreshToken !== undefined) updateData.oauthRefreshToken = oauthFields.oauthRefreshToken;
+            if (oauthFields.oauthIdToken !== undefined) updateData.oauthIdToken = oauthFields.oauthIdToken;
+            if (oauthFields.oauthTokenType !== undefined) updateData.oauthTokenType = oauthFields.oauthTokenType;
+            if (oauthFields.oauthExpiresAt !== undefined) updateData.oauthExpiresAt = oauthFields.oauthExpiresAt;
+            if (oauthFields.oauthScope !== undefined) updateData.oauthScope = oauthFields.oauthScope;
+
+            await prisma.linkedAccount.update({
+                where: { id: linked.id },
+                data: updateData
+            });
+        }
+
+        return linked.user;
+    }
+
+    let user = null;
+    const normalizedEmail = normalizeUsername(rawEmail);
+    if (normalizedEmail) {
+        user = await prisma.user.findUnique({ where: { email: normalizedEmail } });
+    }
+
+    if (!user) {
+        const baseUsername = platformUsername || `${usernamePrefix}${platformUid}`;
+        const username = customGetUsername
+            ? await customGetUsername(baseUsername)
+            : baseUsername;
+
+        const userCount = await prisma.user.count();
+        const role = userCount === 0 ? 'admin' : 'user';
+        const email = normalizedEmail || (customAllocEmail
+            ? await customAllocEmail(platformUid)
+            : `${usernamePrefix}${platformUid}@synthetic.local`);
+
+        user = await prisma.user.create({
+            data: {
+                email,
+                username,
+                passwordHash: await bcrypt.hash(crypto.randomUUID(), 10),
+                displayName,
+                avatarUrl,
+                emailVerified: normalizedEmail ? emailVerified : false,
+                role
+            }
+        });
+
+        logger?.info(`Created local user from ${platform}: user=${user.id}, username=${user.username}`);
+    }
+
+    const linkedAccountData: Record<string, unknown> = {
+        platformUid,
+        platformUsername
+    };
+    if (oauthFields) {
+        if (oauthFields.oauthAccessToken !== undefined) linkedAccountData.oauthAccessToken = oauthFields.oauthAccessToken;
+        if (oauthFields.oauthRefreshToken !== undefined) linkedAccountData.oauthRefreshToken = oauthFields.oauthRefreshToken;
+        if (oauthFields.oauthIdToken !== undefined) linkedAccountData.oauthIdToken = oauthFields.oauthIdToken;
+        if (oauthFields.oauthTokenType !== undefined) linkedAccountData.oauthTokenType = oauthFields.oauthTokenType;
+        if (oauthFields.oauthExpiresAt !== undefined) linkedAccountData.oauthExpiresAt = oauthFields.oauthExpiresAt;
+        if (oauthFields.oauthScope !== undefined) linkedAccountData.oauthScope = oauthFields.oauthScope;
+    }
+
+    await prisma.linkedAccount.upsert({
+        where: {
+            userId_platform: {
+                userId: user.id,
+                platform
+            }
+        },
+        update: linkedAccountData,
+        create: {
+            userId: user.id,
+            platform,
+            ...linkedAccountData
+        }
+    });
+
+    return user;
+}

--- a/server/utils/thirdparty.ts
+++ b/server/utils/thirdparty.ts
@@ -2,16 +2,7 @@ import bcrypt from 'bcryptjs';
 import prisma from '~/server/utils/prisma';
 import { normalizeUsername } from '~/utils/username';
 
-export interface LinkedAccountOAuthFields {
-    oauthAccessToken?: string | null;
-    oauthRefreshToken?: string | null;
-    oauthIdToken?: string | null;
-    oauthTokenType?: string | null;
-    oauthExpiresAt?: Date | null;
-    oauthScope?: string | null;
-}
-
-export interface FindOrCreateLocalUserOptions {
+interface FindOrCreateLocalUserOptions {
     platform: string;
     platformUid: string;
     platformUsername: string;
@@ -20,15 +11,13 @@ export interface FindOrCreateLocalUserOptions {
     displayName: string | null;
     avatarUrl: string | null;
     usernamePrefix: string;
-    oauthFields?: LinkedAccountOAuthFields;
-    /** If true, update OAuth fields on linkedAccount even when user already linked */
-    refreshOnFound?: boolean;
-    /** Custom username generator (overrides default getUniqueUsername with prefix) */
-    getUniqueUsername?: (base: string) => Promise<string>;
-    /** Synthetic email allocator for users without email */
-    allocateSyntheticEmail?: (platformUid: string) => Promise<string>;
-    /** Logger for created user event */
+    getUniqueUsername: (base: string) => Promise<string>;
+    allocateSyntheticEmail: (platformUid: string) => Promise<string>;
     logger?: { info: (msg: string) => void };
+    /** OAuth fields to store in linkedAccount. If already linked and refreshOnFound is true, these fields are updated. */
+    oauthFields?: Record<string, unknown>;
+    /** Update linkedAccount OAuth fields when the user is already linked (Codeforces/Clist do this) */
+    refreshOnFound?: boolean;
 }
 
 export async function findOrCreateLocalUser(opts: FindOrCreateLocalUserOptions) {
@@ -41,61 +30,38 @@ export async function findOrCreateLocalUser(opts: FindOrCreateLocalUserOptions) 
         displayName,
         avatarUrl,
         usernamePrefix,
-        oauthFields,
-        refreshOnFound = false,
-        getUniqueUsername: customGetUsername,
-        allocateSyntheticEmail: customAllocEmail,
-        logger
+        getUniqueUsername,
+        allocateSyntheticEmail,
+        logger,
+        oauthFields = {},
+        refreshOnFound = false
     } = opts;
 
     const linked = await prisma.linkedAccount.findUnique({
-        where: {
-            platform_platformUid: {
-                platform,
-                platformUid
-            }
-        },
+        where: { platform_platformUid: { platform, platformUid } },
         include: { user: true }
     });
 
     if (linked) {
-        if (refreshOnFound && oauthFields) {
-            const updateData: Record<string, unknown> = {
-                platformUsername
-            };
-            if (oauthFields.oauthAccessToken !== undefined) updateData.oauthAccessToken = oauthFields.oauthAccessToken;
-            if (oauthFields.oauthRefreshToken !== undefined) updateData.oauthRefreshToken = oauthFields.oauthRefreshToken;
-            if (oauthFields.oauthIdToken !== undefined) updateData.oauthIdToken = oauthFields.oauthIdToken;
-            if (oauthFields.oauthTokenType !== undefined) updateData.oauthTokenType = oauthFields.oauthTokenType;
-            if (oauthFields.oauthExpiresAt !== undefined) updateData.oauthExpiresAt = oauthFields.oauthExpiresAt;
-            if (oauthFields.oauthScope !== undefined) updateData.oauthScope = oauthFields.oauthScope;
-
+        if (refreshOnFound) {
             await prisma.linkedAccount.update({
                 where: { id: linked.id },
-                data: updateData
+                data: { platformUsername, ...oauthFields }
             });
         }
-
         return linked.user;
     }
 
-    let user = null;
     const normalizedEmail = normalizeUsername(rawEmail);
-    if (normalizedEmail) {
-        user = await prisma.user.findUnique({ where: { email: normalizedEmail } });
-    }
+    let user = normalizedEmail
+        ? await prisma.user.findUnique({ where: { email: normalizedEmail } })
+        : null;
 
     if (!user) {
         const baseUsername = platformUsername || `${usernamePrefix}${platformUid}`;
-        const username = customGetUsername
-            ? await customGetUsername(baseUsername)
-            : baseUsername;
-
+        const username = await getUniqueUsername(baseUsername);
         const userCount = await prisma.user.count();
-        const role = userCount === 0 ? 'admin' : 'user';
-        const email = normalizedEmail || (customAllocEmail
-            ? await customAllocEmail(platformUid)
-            : `${usernamePrefix}${platformUid}@synthetic.local`);
+        const email = normalizedEmail || (await allocateSyntheticEmail(platformUid));
 
         user = await prisma.user.create({
             data: {
@@ -105,39 +71,17 @@ export async function findOrCreateLocalUser(opts: FindOrCreateLocalUserOptions) 
                 displayName,
                 avatarUrl,
                 emailVerified: normalizedEmail ? emailVerified : false,
-                role
+                role: userCount === 0 ? 'admin' : 'user'
             }
         });
 
         logger?.info(`Created local user from ${platform}: user=${user.id}, username=${user.username}`);
     }
 
-    const linkedAccountData: Record<string, unknown> = {
-        platformUid,
-        platformUsername
-    };
-    if (oauthFields) {
-        if (oauthFields.oauthAccessToken !== undefined) linkedAccountData.oauthAccessToken = oauthFields.oauthAccessToken;
-        if (oauthFields.oauthRefreshToken !== undefined) linkedAccountData.oauthRefreshToken = oauthFields.oauthRefreshToken;
-        if (oauthFields.oauthIdToken !== undefined) linkedAccountData.oauthIdToken = oauthFields.oauthIdToken;
-        if (oauthFields.oauthTokenType !== undefined) linkedAccountData.oauthTokenType = oauthFields.oauthTokenType;
-        if (oauthFields.oauthExpiresAt !== undefined) linkedAccountData.oauthExpiresAt = oauthFields.oauthExpiresAt;
-        if (oauthFields.oauthScope !== undefined) linkedAccountData.oauthScope = oauthFields.oauthScope;
-    }
-
     await prisma.linkedAccount.upsert({
-        where: {
-            userId_platform: {
-                userId: user.id,
-                platform
-            }
-        },
-        update: linkedAccountData,
-        create: {
-            userId: user.id,
-            platform,
-            ...linkedAccountData
-        }
+        where: { userId_platform: { userId: user.id, platform } },
+        update: { platformUid, platformUsername, ...oauthFields },
+        create: { userId: user.id, platform, platformUid, platformUsername, ...oauthFields }
     });
 
     return user;


### PR DESCRIPTION
## Summary

Extract the duplicated `findOrCreateLocalUser` function from all four third-party login callbacks into `server/utils/thirdparty.ts`.

**Net reduction: ~128 lines** (5 files changed, 220 insertions, 348 deletions)

## Behavioral Differences Preserved

- **GitHub**: stores accessToken/tokenType/scope
- **Google**: no OAuth fields stored
- **Codeforces/Clist**: refresh OAuth credentials on existing linked account, stores full credential set
- **Clist**: uses `getClistUniqueUsername` instead of `getUniqueUsername`

Each callback retains its own `registerLocalUser` and `bind` functions (not deduplicated — those have more divergent logic).

Closes #58