### PR TITLE
feat(leetcode): registration flow and profile binding UI

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -239,6 +239,7 @@
         "step1_title": "Enter your {platform} UID",
         "step1_desc": "Enter your user ID on {platform}.",
         "step1_desc_atcoder": "Enter your AtCoder username.",
+        "step1_desc_leetcode": "Enter your LeetCode username (the part after /u/ in your profile URL).",
         "uid_placeholder": "e.g. 123456",
         "username_placeholder": "e.g. John",
         "get_code": "Get Verification Code",
@@ -246,6 +247,7 @@
         "step2_title": "Verify Ownership",
         "step2_desc": "Create a public clipboard on {platform} containing the code below, then enter the clipboard ID.",
         "step2_desc_atcoder": "Put the code below into your AtCoder profile Affiliation field, save it, then click Verify directly.",
+        "step2_desc_leetcode": "Put the code below into the bio (About Me) section of your LeetCode profile, save it, then click Verify directly.",
         "atcoder_settings_guide": "Open AtCoder settings to edit Affiliation:",
         "atcoder_cn_plugin_hint": "",
         "code_label": "Verification Code",
@@ -291,6 +293,7 @@
         "platforms": {
             "luogu": "Luogu",
             "atcoder": "AtCoder",
+            "leetcode": "LeetCode",
             "codeforces": "Codeforces",
             "github": "GitHub",
             "google": "Google",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -238,6 +238,7 @@
         "step1_title": "{platform} の UID を入力",
         "step1_desc": "{platform} でのユーザー ID を入力してください。",
         "step1_desc_atcoder": "AtCoder のユーザー名を入力してください。",
+        "step1_desc_leetcode": "LeetCode のユーザー名を入力してください(プロフィール URL の /u/ の後の部分)。",
         "uid_placeholder": "例: 123456",
         "username_placeholder": "例: John",
         "get_code": "認証コードを取得",
@@ -245,6 +246,7 @@
         "step2_title": "所有権の確認",
         "step2_desc": "{platform} で以下のコードを含む公開クリップボードを作成し、クリップボード ID を入力してください。",
         "step2_desc_atcoder": "以下のコードを AtCoder プロフィールの Affiliation に設定して保存し、そのまま確認を押してください。",
+        "step2_desc_leetcode": "下記の認証コードを LeetCode プロフィールの自己紹介(About Me)に貼り付け、保存してから「検証」をクリックしてください。",
         "atcoder_settings_guide": "Affiliation は AtCoder 設定ページで編集できます：",
         "atcoder_cn_plugin_hint": "",
         "code_label": "認証コード",
@@ -290,6 +292,7 @@
         "platforms": {
             "luogu": "Luogu",
             "atcoder": "AtCoder",
+            "leetcode": "LeetCode",
             "codeforces": "Codeforces",
             "github": "GitHub",
             "google": "Google",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -239,6 +239,7 @@
         "step1_title": "输入你的 {platform} UID",
         "step1_desc": "输入你在 {platform} 上的用户 ID。",
         "step1_desc_atcoder": "输入你在 AtCoder 上的用户名。",
+        "step1_desc_leetcode": "请输入您的 LeetCode 用户名（个人主页 URL 中 /u/ 之后的部分）。",
         "uid_placeholder": "例如 123456",
         "username_placeholder": "例如 John",
         "get_code": "获取验证码",
@@ -246,6 +247,7 @@
         "step2_title": "验证所有权",
         "step2_desc": "在 {platform} 上创建一个包含以下验证码的公开剪贴板，然后输入剪贴板 ID。",
         "step2_desc_atcoder": "将以下验证码写入 AtCoder 个人主页的 Affiliation 字段并保存，然后直接点击确认即可。",
+        "step2_desc_leetcode": "将下方验证码粘贴到您 LeetCode 个人简介（About Me）中，保存后直接点击验证。",
         "atcoder_settings_guide": "请前往 AtCoder 设置页编辑 Affiliation：",
         "atcoder_cn_plugin_hint": "中文用户提示：如果安装了 AtCoder Better 插件，Affiliation 可能会被翻译成“机构”。",
         "code_label": "验证码",
@@ -291,6 +293,7 @@
         "platforms": {
             "luogu": "洛谷",
             "atcoder": "AtCoder",
+            "leetcode": "LeetCode",
             "codeforces": "Codeforces",
             "github": "GitHub",
             "google": "Google",

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -243,6 +243,15 @@
                                 >
                             </span>
                         </el-button>
+                        <el-button :disabled="leetcodeLinked" @click="openBindDialog('leetcode')">
+                            <span class="profile__bind-btn-content">
+                                <AppPlatformIcon platform="leetcode" />
+                                <span
+                                    >{{ $t('binding.link_account') }} —
+                                    {{ $t('binding.platforms.leetcode') }}</span
+                                >
+                            </span>
+                        </el-button>
                         <el-button :disabled="codeforcesLinked" @click="handleBindCodeforcesOAuth">
                             <span class="profile__bind-btn-content">
                                 <AppPlatformIcon platform="codeforces" />
@@ -656,7 +665,10 @@
                             })
                         }}
                     </p>
-                    <p v-if="isAtcoderBinding" class="profile__bind-desc profile__bind-desc--minor">
+                    <p
+                        v-if="isUsernameBasedBinding"
+                        class="profile__bind-desc profile__bind-desc--minor"
+                    >
                         {{ $t('binding.atcoder_settings_guide') }}
                         <a
                             href="https://atcoder.jp/settings"
@@ -667,7 +679,7 @@
                         </a>
                     </p>
                     <p
-                        v-if="isAtcoderBinding && locale === 'zh'"
+                        v-if="isUsernameBasedBinding && locale === 'zh'"
                         class="profile__bind-desc profile__bind-desc--minor"
                     >
                         {{ $t('binding.atcoder_cn_plugin_hint') }}
@@ -685,7 +697,7 @@
                         </p>
                     </div>
                     <el-input
-                        v-if="!isAtcoderBinding"
+                        v-if="!isUsernameBasedBinding"
                         v-model="bindCredential"
                         :placeholder="$t(bindCredentialPlaceholderKey)"
                         class="profile__bind-input"
@@ -694,7 +706,7 @@
                         <el-button
                             type="primary"
                             :loading="bindLoading"
-                            :disabled="!isAtcoderBinding && !bindCredential.trim()"
+                            :disabled="!isUsernameBasedBinding && !bindCredential.trim()"
                             @click="handleVerify"
                         >
                             {{ bindLoading ? $t('binding.verifying') : $t('binding.verify') }}
@@ -1277,21 +1289,30 @@ const luoguLinked = computed(() => bindings.value.some(account => account.platfo
 const atcoderLinked = computed(() =>
     bindings.value.some(account => account.platform === 'atcoder')
 );
+const leetcodeLinked = computed(() =>
+    bindings.value.some(account => account.platform === 'leetcode')
+);
 const codeforcesLinked = computed(() =>
     bindings.value.some(account => account.platform === 'codeforces')
 );
 const githubLinked = computed(() => bindings.value.some(account => account.platform === 'github'));
 const googleLinked = computed(() => bindings.value.some(account => account.platform === 'google'));
 const clistLinked = computed(() => bindings.value.some(account => account.platform === 'clist'));
-const bindStep2DescKey = computed(() =>
-    bindPlatform.value === 'atcoder' ? 'binding.step2_desc_atcoder' : 'binding.step2_desc'
+const bindStep2DescKey = computed(() => {
+    if (bindPlatform.value === 'atcoder') return 'binding.step2_desc_atcoder';
+    if (bindPlatform.value === 'leetcode') return 'binding.step2_desc_leetcode';
+    return 'binding.step2_desc';
+});
+const isUsernameBasedBinding = computed(
+    () => bindPlatform.value === 'atcoder' || bindPlatform.value === 'leetcode'
 );
-const isAtcoderBinding = computed(() => bindPlatform.value === 'atcoder');
-const bindStep1DescKey = computed(() =>
-    bindPlatform.value === 'atcoder' ? 'binding.step1_desc_atcoder' : 'binding.step1_desc'
-);
+const bindStep1DescKey = computed(() => {
+    if (bindPlatform.value === 'atcoder') return 'binding.step1_desc_atcoder';
+    if (bindPlatform.value === 'leetcode') return 'binding.step1_desc_leetcode';
+    return 'binding.step1_desc';
+});
 const bindUidPlaceholderKey = computed(() =>
-    bindPlatform.value === 'atcoder' ? 'binding.username_placeholder' : 'binding.uid_placeholder'
+    isUsernameBasedBinding.value ? 'binding.username_placeholder' : 'binding.uid_placeholder'
 );
 const bindCredentialPlaceholderKey = computed(() =>
     bindPlatform.value === 'atcoder'
@@ -1402,7 +1423,7 @@ async function handleVerify() {
             headers: { Authorization: `Bearer ${token.value}` },
             body: {
                 platform: bindPlatform.value,
-                credential: isAtcoderBinding.value ? '' : bindCredential.value.trim()
+                credential: isUsernameBasedBinding.value ? '' : bindCredential.value.trim()
             }
         });
         ElMessage.success(t('binding.verify_success'));

--- a/server/api/auth/me.ts
+++ b/server/api/auth/me.ts
@@ -15,6 +15,7 @@ export default defineEventHandler(async event => {
     const allowedPublicPlatforms = new Set([
         'luogu',
         'atcoder',
+        'leetcode',
         'codeforces',
         'github',
         'google',

--- a/server/api/auth/thirdparty/leetcode/register/request.post.ts
+++ b/server/api/auth/thirdparty/leetcode/register/request.post.ts
@@ -1,0 +1,57 @@
+import crypto from 'crypto';
+import { getPlatformVerifier } from '~/server/utils/platforms';
+import prisma from '~/server/utils/prisma';
+import { getRedis } from '~/server/utils/redis';
+import { verifyTurnstileToken } from '~/server/utils/turnstile';
+
+export default defineEventHandler(async event => {
+    const body = await readBody(event);
+    const platformUid = String(body.platformUid || '').trim();
+    const turnstileToken = String(body.turnstileToken || '');
+
+    await verifyTurnstileToken({
+        token: turnstileToken,
+        action: 'leetcode:register:request'
+    });
+
+    if (!platformUid) {
+        throw createError({ statusCode: 400, message: 'Platform UID is required' });
+    }
+
+    const verifier = getPlatformVerifier('leetcode');
+    if (!verifier) {
+        throw createError({ statusCode: 500, message: 'LeetCode verifier is unavailable' });
+    }
+
+    const taken = await prisma.linkedAccount.findUnique({
+        where: {
+            platform_platformUid: {
+                platform: 'leetcode',
+                platformUid
+            }
+        },
+        select: { id: true }
+    });
+    if (taken) {
+        throw createError({
+            statusCode: 409,
+            message: 'This LeetCode account is already linked by another user'
+        });
+    }
+
+    const requestId = crypto.randomBytes(12).toString('hex');
+    const code = `CPOAUTH-REG-${crypto.randomBytes(4).toString('hex').toUpperCase()}`;
+
+    await getRedis().set(
+        `auth:leetcode:register:${requestId}`,
+        JSON.stringify({ code, platformUid }),
+        'EX',
+        600
+    );
+
+    return {
+        requestId,
+        code,
+        expiresIn: 600
+    };
+});

--- a/server/api/auth/thirdparty/leetcode/register/verify.post.ts
+++ b/server/api/auth/thirdparty/leetcode/register/verify.post.ts
@@ -1,0 +1,114 @@
+import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
+import { getPlatformVerifier } from '~/server/utils/platforms';
+import prisma from '~/server/utils/prisma';
+import { getRedis } from '~/server/utils/redis';
+import { getUniqueUsername } from '~/server/utils/codeforces-oauth';
+import { createAuthUserResponse } from '~/server/utils/user-response';
+import { fetchLeetcodeProfile } from '~/server/utils/leetcode-fetch';
+
+async function allocateSyntheticLeetcodeEmail(platformUid: string): Promise<string> {
+    const base = `leetcode_${platformUid.replace(/[^A-Za-z0-9_]/g, '_')}`.slice(0, 40);
+    for (let i = 0; i <= 9999; i += 1) {
+        const suffix = i === 0 ? '' : `_${i}`;
+        const candidate = `${base}${suffix}@leetcode.local`;
+        const exists = await prisma.user.findUnique({
+            where: { email: candidate },
+            select: { id: true }
+        });
+        if (!exists) {
+            return candidate;
+        }
+    }
+    throw createError({ statusCode: 500, message: 'Unable to allocate email for LeetCode user' });
+}
+
+export default defineEventHandler(async event => {
+    const body = await readBody(event);
+    const requestId = String(body.requestId || '').trim();
+    const credential = String(body.credential || '').trim();
+
+    if (!requestId || !credential) {
+        throw createError({ statusCode: 400, message: 'requestId and credential are required' });
+    }
+
+    const redis = getRedis();
+    const key = `auth:leetcode:register:${requestId}`;
+    const raw = await redis.get(key);
+    if (!raw) {
+        throw createError({
+            statusCode: 400,
+            message: 'Registration request expired or not found'
+        });
+    }
+
+    const { code, platformUid } = JSON.parse(raw) as { code: string; platformUid: string };
+
+    const verifier = getPlatformVerifier('leetcode');
+    if (!verifier) {
+        throw createError({ statusCode: 500, message: 'LeetCode verifier is unavailable' });
+    }
+
+    const result = await verifier.verify({ platformUid, code, credential });
+    if (!result.success) {
+        throw createError({ statusCode: 400, message: result.error || 'Verification failed' });
+    }
+
+    const taken = await prisma.linkedAccount.findUnique({
+        where: {
+            platform_platformUid: {
+                platform: 'leetcode',
+                platformUid: result.platformUid
+            }
+        },
+        select: { id: true }
+    });
+    if (taken) {
+        throw createError({
+            statusCode: 409,
+            message: 'This LeetCode account has already registered'
+        });
+    }
+
+    const username = await getUniqueUsername(
+        result.platformUsername || `leetcode_${result.platformUid}`
+    );
+    const email = await allocateSyntheticLeetcodeEmail(result.platformUid);
+    const userCount = await prisma.user.count();
+    const role = userCount === 0 ? 'admin' : 'user';
+
+    const profile = await fetchLeetcodeProfile(result.platformUid);
+    const avatarUrl = profile?.userAvatar || null;
+
+    const user = await prisma.user.create({
+        data: {
+            email,
+            username,
+            passwordHash: await bcrypt.hash(crypto.randomUUID(), 10),
+            displayName: result.platformUsername || null,
+            avatarUrl,
+            emailVerified: false,
+            role
+        },
+        select: { id: true, username: true, displayName: true, email: true }
+    });
+
+    await prisma.linkedAccount.create({
+        data: {
+            userId: user.id,
+            platform: 'leetcode',
+            platformUid: result.platformUid,
+            platformUsername: result.platformUsername || null
+        }
+    });
+
+    await redis.del(key);
+
+    const token = await signAuthToken(user.id);
+
+    return {
+        token,
+        user: createAuthUserResponse(user),
+        mode: 'register'
+    };
+});

--- a/server/api/oauth/userinfo.get.ts
+++ b/server/api/oauth/userinfo.get.ts
@@ -25,6 +25,7 @@ interface OAuthPayload {
 const LINK_SCOPE_PLATFORMS = [
     'luogu',
     'atcoder',
+    'leetcode',
     'codeforces',
     'github',
     'google',


### PR DESCRIPTION
Part 2 of 2 for LeetCode account integration (after #42). Adds the user-facing registration endpoints and the binding UI in the profile page, so users can link a LeetCode account from settings and (in principle) register a new cp-oauth account via LeetCode.

Changes:

- New: server/api/auth/thirdparty/leetcode/register/{request,verify}.post.ts — mirror the Luogu register flow. request.post.ts issues a one-time verification code keyed by a requestId in Redis (10 min TTL). verify.post.ts checks the code via the leetcodeVerifier (which reads the LeetCode aboutMe field), creates a new user with a synthetic email (leetcode_<slug>@leetcode.local), links the LeetCode account, and signs an auth token.

- Modified: pages/profile.vue — adds a LeetCode bind button next to AtCoder. Refactors isAtcoderBinding to isUsernameBasedBinding (now true for both atcoder and leetcode) to share the 'enter username, paste code into profile bio' flow. Adds leetcode branches to bindStep1DescKey and bindStep2DescKey for LeetCode-specific instructions.

- Modified: server/api/auth/me.ts — adds leetcode to allowedPublicPlatforms so users can mark a linked LeetCode account public.

- Modified: server/api/oauth/userinfo.get.ts — adds leetcode to LINK_SCOPE_PLATFORMS so the link:leetcode scope (defined in #42) is recognized.

- Modified: i18n/locales/{en,zh,ja}.json — adds LeetCode platform name and step1/step2 descriptions specific to LeetCode (instructing users to paste the code into their 'About Me' bio).

Design notes:

- The avatar URL is fetched from LeetCode's GraphQL userAvatar field (added to leetcode-fetch.ts in #42), avoiding the need for a hardcoded default avatar URL pattern. Falls back to null if unavailable; cp-oauth's default avatar will be used in that case.

- isAtcoderBinding renamed to isUsernameBasedBinding because the same UI flow (username input, no separate credential field, paste code into profile bio) now applies to two platforms. Future platforms with the same pattern can be added with one || check.

- Japanese translation provided as best-effort by a non-native speaker; community polish welcome.

Closes the LeetCode integration work in conjunction with #42.