### PR TITLE
fix: map LeetCode Clist resource

### DIFF
--- a/components/AppPlatformIcon.vue
+++ b/components/AppPlatformIcon.vue
@@ -18,6 +18,7 @@ const RESOURCE_TO_ICON: Record<string, string> = {
     'atcoder.jp': 'atcoder',
     'atcoder.jp/heuristic': 'atcoder',
     'luogu.com.cn': 'luogu',
+    'leetcode.com': 'leetcode',
     'github.com': 'github',
     'google.com': 'google',
     'clist.by': 'clist'
@@ -46,6 +47,9 @@ const iconSrc = computed(() => {
     }
     if (p === 'luogu') {
         return `${baseUrl.value}icons/luogu.svg`;
+    }
+    if (p === 'leetcode') {
+        return `${baseUrl.value}icons/leetcode.svg`;
     }
     // Fallback: try simpleicons by domain name (strip TLD)
     const name = props.platform.replace(/\..+$/, '');

--- a/server/utils/clist-api.ts
+++ b/server/utils/clist-api.ts
@@ -18,7 +18,8 @@ const CODER_ME_CACHE_TTL = 24 * 60 * 60; // 1 day
 export const RESOURCE_TO_PLATFORM: Record<string, string> = {
     'codeforces.com': 'codeforces',
     'atcoder.jp': 'atcoder',
-    'luogu.com.cn': 'luogu'
+    'luogu.com.cn': 'luogu',
+    'leetcode.com': 'leetcode'
 };
 
 export const PLATFORM_TO_RESOURCE: Record<string, string> = Object.fromEntries(


### PR DESCRIPTION
## Summary
- map Clist's leetcode.com resource to the local leetcode platform
- use the local LeetCode icon for Clist-derived LeetCode resources
- fixes the previously reported issue where LeetCode Clist stats were filtered out by the missing resource mapping

Closes #63

## Checks
- npm run lint