### PR TITLE
fix(profile): send LeetCode username as credential in bind verify

### DIFF
--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -1423,7 +1423,12 @@ async function handleVerify() {
             headers: { Authorization: `Bearer ${token.value}` },
             body: {
                 platform: bindPlatform.value,
-                credential: isUsernameBasedBinding.value ? '' : bindCredential.value.trim()
+                credential:
+                    bindPlatform.value === 'atcoder'
+                        ? ''
+                        : bindPlatform.value === 'leetcode'
+                          ? bindUid.value.trim()
+                          : bindCredential.value.trim()
             }
         });
         ElMessage.success(t('binding.verify_success'));


### PR DESCRIPTION
Reported in #62 by @GWBailang553.

The bind verify endpoint requires a non-empty credential for all platforms except AtCoder, which is the only platform whose verifier ignores it (atcoder verifies ownership by reading the platform UID's profile Affiliation directly).

Before this fix, the frontend sent an empty credential for any 'isUsernameBasedBinding' platform — which covered both AtCoder and LeetCode after #61. AtCoder worked because the backend has a special case for it. LeetCode failed with '400 Credential is required' before reaching the verifier, since the LeetCode verifier needs the userSlug as credential to fetch the profile via GraphQL.

Now the credential field is set per-platform: '' for AtCoder, the entered username for LeetCode, and the credential input box for everything else. isUsernameBasedBinding is retained for the template (it still correctly controls whether to show the separate credential input field).

Note: #63 (Clist resource mapping for leetcode.com) is intentionally not addressed here — cp-oauth's LeetCode integration targets leetcode.cn (Chinese site), while Clist's leetcode.com resource is the international site. The two sites' user data are not interchangeable, so adding the mapping would surface mismatched data. Will be revisited if international site support is added later.

Closes #62