### PR TITLE
fix(oauth): build callback URL with URL API to preserve existing query strings

### DIFF
--- a/server/api/oauth/authorize.post.ts
+++ b/server/api/oauth/authorize.post.ts
@@ -5,6 +5,16 @@ import { generateCode, isSafeOAuthRedirectUri, validateScopes } from '~/server/u
 
 const logger = consola.withTag('oauth:authorize');
 
+function buildCallbackUrl(redirectUri: string, params: Record<string, string | undefined>): string {
+    const url = new URL(redirectUri);
+    for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined) {
+            url.searchParams.set(key, value);
+        }
+    }
+    return url.toString();
+}
+
 export default defineEventHandler(async event => {
     const userId = getUserIdFromEvent(event);
     const body = await readBody(event);
@@ -41,7 +51,7 @@ export default defineEventHandler(async event => {
 
     if (!approved) {
         logger.info(`User ${userId} denied authorization for client_id=${clientId}`);
-        return { redirect: `${redirectUri}?error=access_denied${state ? `&state=${state}` : ''}` };
+        return { redirect: buildCallbackUrl(redirectUri, { error: 'access_denied', state }) };
     }
 
     const code = generateCode();
@@ -60,12 +70,9 @@ export default defineEventHandler(async event => {
         }
     });
 
-    const params = new URLSearchParams({ code });
-    if (state) params.set('state', state);
-
     logger.success(
         `Authorization code issued for user ${userId} → client "${client.name}" (${clientId}), scopes=[${scopes.join(', ')}]`
     );
 
-    return { redirect: `${redirectUri}?${params.toString()}` };
+    return { redirect: buildCallbackUrl(redirectUri, { code, state }) };
 });


### PR DESCRIPTION
Reported in #67 by @GWBailang553.

The OAuth authorize endpoint built callback URLs by concatenating '?' and parameters directly onto redirectUri. If a registered client redirect URI already contained a query string (e.g. 'https://client.example/callback?next=/app'), the result was a malformed URL with two '?' characters.

RFC 6749 §3.1.2 allows redirect URIs to include a query component, and the client registration endpoint already accepts such URIs via isSafeOAuthRedirectUri. The authorize endpoint, however, assumed redirectUri had no query string, breaking OAuth callbacks for any client with a query-bearing redirect URI.

Fix: introduce a buildCallbackUrl helper that uses the URL/URLSearchParams API to merge parameters onto redirectUri correctly, regardless of whether it already has a query string. Both the access_denied response and the success response use the helper, so future redirect paths (e.g. additional RFC 6749 error codes) won't reintroduce the bug.

Closes #67