### PR TITLE
fix(auth) #74: reset Turnstile on login error handling

### DIFF
--- a/pages/login.vue
+++ b/pages/login.vue
@@ -429,6 +429,7 @@ async function handleGitHubLogin() {
     } catch (e: unknown) {
         const err = e as { data?: { message?: string } };
         ElMessage.error(err.data?.message || t('auth.login.error'));
+        resetTurnstile();
     } finally {
         githubLoading.value = false;
     }
@@ -450,6 +451,7 @@ async function handleGoogleLogin() {
     } catch (e: unknown) {
         const err = e as { data?: { message?: string } };
         ElMessage.error(err.data?.message || t('auth.login.error'));
+        resetTurnstile();
     } finally {
         googleLoading.value = false;
     }
@@ -471,6 +473,7 @@ async function handleCodeforcesLogin() {
     } catch (e: unknown) {
         const err = e as { data?: { message?: string } };
         ElMessage.error(err.data?.message || t('auth.login.error'));
+        resetTurnstile();
     } finally {
         codeforcesLoading.value = false;
     }
@@ -492,6 +495,7 @@ async function handleClistLogin() {
     } catch (e: unknown) {
         const err = e as { data?: { message?: string } };
         ElMessage.error(err.data?.message || t('auth.login.error'));
+        resetTurnstile();
     } finally {
         clistLoading.value = false;
     }

--- a/pages/oauth/thirdparty/luogu.vue
+++ b/pages/oauth/thirdparty/luogu.vue
@@ -137,7 +137,11 @@ interface PublicConfigResponse {
 const { data: publicConfig } = await useFetch<PublicConfigResponse>('/api/public/config');
 const turnstileEnabled = computed(() => publicConfig.value?.turnstileEnabled || false);
 const turnstileSiteKey = computed(() => publicConfig.value?.turnstileSiteKey || '');
-const { token: turnstileToken, el: turnstileEl } = useTurnstile(turnstileSiteKey);
+const {
+    token: turnstileToken,
+    el: turnstileEl,
+    reset: resetTurnstile
+} = useTurnstile(turnstileSiteKey);
 const thirdPartyCaptchaReady = computed(
     () => !turnstileEnabled.value || Boolean(turnstileToken.value)
 );
@@ -166,6 +170,7 @@ async function handleLuoguCredentialLogin() {
     } catch (e: unknown) {
         const err = e as { data?: { message?: string } };
         ElMessage.error(err.data?.message || t('auth.login.error'));
+        resetTurnstile();
     } finally {
         loading.value = false;
     }
@@ -191,6 +196,7 @@ async function handleChallengeRequest() {
     } catch (e: unknown) {
         const err = e as { data?: { message?: string } };
         ElMessage.error(err.data?.message || t('auth.login.error'));
+        resetTurnstile();
     } finally {
         loading.value = false;
     }
@@ -214,6 +220,7 @@ async function handleChallengeVerify() {
     } catch (e: unknown) {
         const err = e as { data?: { message?: string } };
         ElMessage.error(err.data?.message || t('auth.login.error'));
+        resetTurnstile();
     } finally {
         loading.value = false;
     }

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -101,7 +101,11 @@ const { data: publicConfig } = await useFetch<PublicConfigResponse>('/api/public
 const siteTitle = computed(() => publicConfig.value?.siteTitle || t('app.name'));
 const turnstileEnabled = computed(() => publicConfig.value?.turnstileEnabled || false);
 const turnstileSiteKey = computed(() => publicConfig.value?.turnstileSiteKey || '');
-const { token: turnstileToken, el: turnstileEl } = useTurnstile(turnstileSiteKey);
+const {
+    token: turnstileToken,
+    el: turnstileEl,
+    reset: resetTurnstile
+} = useTurnstile(turnstileSiteKey);
 
 async function handleRegister() {
     if (!formRef.value) return;
@@ -124,6 +128,7 @@ async function handleRegister() {
     } catch (e: unknown) {
         const err = e as { data?: { message?: string } };
         ElMessage.error(err.data?.message || t('auth.register.error'));
+        resetTurnstile();
     } finally {
         loading.value = false;
     }


### PR DESCRIPTION
修复了所有 3 个使用 Cloudflare Turnstile 验证码的页面，确保在任何提交失败时都能自动刷新验证码：

- pages/register.vue：解构 reset 并在 handleRegister catch 中调用 resetTurnstile()
- pages/login.vue：4 个 OAuth handler（GitHub/Google/Codeforces/Clist）的 catch 块新增 resetTurnstile()
- pages/oauth/thirdparty/luogu.vue：解构 reset 并在 3 个函数（credential login、challenge request、challenge verify）的 catch 块中调用 resetTurnstile()

Closes #74